### PR TITLE
Let CyanogenMod developers know of Clark Scheff and Steve Kondik's gd…

### DIFF
--- a/debuggerd/debuggerd.cpp
+++ b/debuggerd/debuggerd.cpp
@@ -15,6 +15,8 @@
  * limitations under the License.
  */
 
+#define LOG_TAG "DEBUG"
+
 #include <stdio.h>
 #include <errno.h>
 #include <signal.h>
@@ -75,11 +77,13 @@ static void wait_for_user_action(const debugger_request_t &request) {
         "* and start gdbclient:\n"
         "*\n"
         "*     gdbclient %s :5039 %d\n"
+        "* or\n"
+        "*     dddclient %s :5039 %d\n"
         "*\n"
         "* Wait for gdb to start, then press the VOLUME DOWN key\n"
         "* to let the process continue crashing.\n"
         "********************************************************\n",
-        request.pid, exe, request.tid);
+        request.pid, exe, request.tid, exe, request.tid);
 
   // Wait for VOLUME DOWN.
   if (init_getevent() == 0) {
@@ -278,7 +282,19 @@ static bool should_attach_gdb(debugger_request_t* request) {
     char value[PROPERTY_VALUE_MAX];
     property_get("debug.db.uid", value, "-1");
     int debug_uid = atoi(value);
-    return debug_uid >= 0 && request->uid <= (uid_t)debug_uid;
+    if (debug_uid >= 0 && request->uid <= (uid_t)debug_uid) {
+      return true;
+    } else {
+      /* External docs say to use 10,000 but more is likely needed; be helpful. */
+      if (request->uid > (uid_t)debug_uid) {
+        ALOGI("request->uid:%d > property debug.db.uid:%d; NOT waiting for gdb.",
+               request->uid,                 debug_uid);
+      } else {
+        ALOGI("property debug.db.uid not set; NOT waiting for gdb.");
+        ALOGI("HINT: adb shell setprop debug.db.uid 100000");
+        ALOGI("HINT: adb forward tcp:5039 tcp:5039");
+      }
+    }
   }
   return false;
 }


### PR DESCRIPTION
…b fix.

Also, let users know that they set the property debug.db.uid
too low to enable debuggerd to wait for gdb to attach.

If they haven't set debug.db.uid; let them know; and offer a hint
on how to do it, without their having to Google for the web page.

The web page is actually wrong suggesting uid == 10,000;
100,000 would be a better suggestion.

Change-Id: I467d861c0fffe34e8532a8bc7cf7bfdab9f56447
Signed-off-by: Pete Delaney piet@cyngn.com
